### PR TITLE
Add support for observing and modifying the selected text range.

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Select latest available Xcode
         uses: maxim-lobanov/setup-xcode@v1.2.1
         with:
-          xcode-version: 12.2
+          xcode-version: 13.2.1
       - name: Checkout Repository
         uses: actions/checkout@v2
       - name: Build Swift Debug Package

--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ To persist the size, the `fontSize` binding is available.
      }
  }
  ```
+ When `autoscroll` is `true`, the editor automatically scrolls to the respective
+ cursor position when `selection` is modfied from the outside, i.e. programatically.
 
 ### Highlightr and Shaper
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,30 @@ WindowGroup {
 To persist the size, the `fontSize` binding is available.
 
 
+ ### Selection and Scrolling
+ 
+ The selected text can be observed and modified via another `Binding`:
+ 
+ ```swift
+  struct ContentView: View {
+     static private let initialSource = "let a = 42\n"
+
+     @State private var source = Self.initialSource
+     @State private var selection = Self.initialSource.endIndex..<Self.initialSource.endIndex
+
+     var body: some View {
+         CodeEditor(source: $source,
+                    selection: $selection,
+                    language: .swift,
+                    theme: .ocean,
+                    autoscroll: false)
+         Button("Select All") {
+             selection = source.startIndex..<source.endIndex
+         }
+     }
+ }
+ ```
+
 ### Highlightr and Shaper
 
 Based on the excellent [Highlightr](https://github.com/raspu/Highlightr).

--- a/Sources/CodeEditor/UXCodeTextView.swift
+++ b/Sources/CodeEditor/UXCodeTextView.swift
@@ -264,7 +264,7 @@ protocol UXCodeTextViewDelegate: UXTextViewDelegate {
 
 extension UXTextView {
   
-  fileprivate var swiftSelectedRange : Range<String.Index> {
+  var swiftSelectedRange : Range<String.Index> {
     let s = self.string
     guard !s.isEmpty else { return s.startIndex..<s.startIndex }
     #if os(macOS)

--- a/Sources/CodeEditor/UXCodeTextViewRepresentable.swift
+++ b/Sources/CodeEditor/UXCodeTextViewRepresentable.swift
@@ -86,18 +86,20 @@ struct UXCodeTextViewRepresentable : UXViewRepresentable {
       self.parent = parent
     }
     
-    public func textDidChange(_ notification: Notification) {
-      guard let textView = notification.object as? UXTextView else {
-        assertionFailure("unexpected notification object")
-        return
+    #if os(macOS)
+      public func textDidChange(_ notification: Notification) {
+        guard let textView = notification.object as? UXTextView else {
+          assertionFailure("unexpected notification object")
+          return
+        }
+        parent.source.wrappedValue = textView.string
+      }    
+    #elseif os(iOS)
+      public func textViewDidChange(_ textView: UITextView) {
+        parnt.source.wrappedValue = textView.string
       }
-      parent.source.wrappedValue = textView.string
-    }
-    
-    #if os(iOS)
-    public func textViewDidChange(_ textView: UITextView) {
-      parent.source.wrappedValue = textView.string
-    }
+    #else
+      #error("Unsupported OS")
     #endif
     
     var allowCopy: Bool {

--- a/Sources/CodeEditor/UXCodeTextViewRepresentable.swift
+++ b/Sources/CodeEditor/UXCodeTextViewRepresentable.swift
@@ -118,10 +118,11 @@ struct UXCodeTextViewRepresentable : UXViewRepresentable {
     #endif
       
     private func textViewDidChange(textView: UXTextView) {
-      // This function may be called as a consequence of calling
-      // `textView.setSelectedRange(_:)` in UXCodeTextViewRepresentable/updateTextView(_:)`.
-      // Since this function might update the `parent.selection` `Binding`, which in
+      // This function may be called as a consequence of updating the text string
+      //  in UXCodeTextViewRepresentable/updateTextView(_:)`.
+      // Since this function might update the `parent.source` `Binding`, which in
       // turn might update a `State`, this would lead to undefined behavior.
+      // (Changing a `State` during a `View` update is not permitted).
       guard !parent.isCurrentlyUpdatingView.value else {
         return
       }
@@ -147,10 +148,11 @@ struct UXCodeTextViewRepresentable : UXViewRepresentable {
     #endif
       
     private func textViewDidChangeSelection(textView: UXCodeTextView) {
-      // This function may be called as a consequence of calling
-      // `textView.setSelectedRange(_:)` in UXCodeTextViewRepresentable/updateTextView(_:)`.
+      // This function may be called as a consequence of updating the selected
+      // range in UXCodeTextViewRepresentable/updateTextView(_:)`.
       // Since this function might update the `parent.selection` `Binding`, which in
       // turn might update a `State`, this would lead to undefined behavior.
+      // (Changing a `State` during a `View` update is not permitted).
       guard !parent.isCurrentlyUpdatingView.value else {
         return
       }

--- a/Sources/CodeEditor/UXCodeTextViewRepresentable.swift
+++ b/Sources/CodeEditor/UXCodeTextViewRepresentable.swift
@@ -41,17 +41,22 @@ struct UXCodeTextViewRepresentable : UXViewRepresentable {
    *                  the opening character. For example: `[ "<": ">" ]` would
    *                  automatically insert the closing ">" if the user enters
    *                  "<".
+   *   - autoscroll:  If enabled, the editor automatically scrolls to the respective
+   *                  region when the `selection` is changed programatically.
    */
   public init(source      : Binding<String>,
+              selection   : Binding<Range<String.Index>>?,
               language    : CodeEditor.Language?,
               theme       : CodeEditor.ThemeName,
               fontSize    : Binding<CGFloat>?,
               flags       : CodeEditor.Flags,
               indentStyle : CodeEditor.IndentStyle,
               autoPairs   : [ String : String ],
-              inset       : CGSize)
+              inset       : CGSize,
+              autoscroll  : Bool)
   {
     self.source      = source
+    self.selection = selection
     self.fontSize    = fontSize
     self.language    = language
     self.themeName   = theme
@@ -59,9 +64,11 @@ struct UXCodeTextViewRepresentable : UXViewRepresentable {
     self.indentStyle = indentStyle
     self.autoPairs   = autoPairs
     self.inset       = inset
+    self.autoscroll = autoscroll
   }
     
   private var source      : Binding<String>
+  private var selection   : Binding<Range<String.Index>>?
   private var fontSize    : Binding<CGFloat>?
   private let language    : CodeEditor.Language?
   private let themeName   : CodeEditor.ThemeName
@@ -69,6 +76,7 @@ struct UXCodeTextViewRepresentable : UXViewRepresentable {
   private let indentStyle : CodeEditor.IndentStyle
   private let inset       : CGSize
   private let autoPairs   : [ String : String ]
+  private let autoscroll  : Bool
   
   
   // MARK: - TextView Delegate  Coordinator
@@ -101,6 +109,28 @@ struct UXCodeTextViewRepresentable : UXViewRepresentable {
     #else
       #error("Unsupported OS")
     #endif
+      
+    public func textViewDidChangeSelection(_ notification: Notification) {
+      guard let textView = notification.object as? UXTextView else {
+        assertionFailure("unexpected notification object")
+        return
+      }
+      
+      guard let selection = parent.selection else {
+        return
+      }
+
+      guard let range = Range(textView.selectedRange(), in: textView.string) else {
+        assertionFailure("could not convert NSRange to Range")
+        return
+      }
+        
+      DispatchQueue.main.async {
+        if selection.wrappedValue != range {
+          selection.wrappedValue = range
+        }
+      }
+    }
     
     var allowCopy: Bool {
       return parent.flags.contains(.selectable)
@@ -133,6 +163,18 @@ struct UXCodeTextViewRepresentable : UXViewRepresentable {
       else {
         assertionFailure("no text storage?")
         textView.string = source.wrappedValue
+      }
+    }
+    
+    if let selection = selection {
+      let range = NSRange(selection.wrappedValue, in: textView.string)
+      
+      if range != textView.selectedRange() {
+        textView.setSelectedRange(range)
+        
+        if autoscroll {
+          textView.scrollRangeToVisible(range)
+        }
       }
     }
     
@@ -202,23 +244,27 @@ struct UXCodeTextViewRepresentable_Previews: PreviewProvider {
   static var previews: some View {
     
     UXCodeTextViewRepresentable(source      : .constant("let a = 5"),
+                                selection   : nil,
                                 language    : nil,
                                 theme       : .pojoaque,
                                 fontSize    : nil,
                                 flags       : [ .selectable ],
                                 indentStyle : .system,
                                 autoPairs   : [:],
-                                inset       : .init(width: 8, height: 8))
+                                inset       : .init(width: 8, height: 8),
+                                autoscroll  : false)
       .frame(width: 200, height: 100)
     
     UXCodeTextViewRepresentable(source: .constant("let a = 5"),
+                                selection   : nil,
                                 language    : .swift,
                                 theme       : .pojoaque,
                                 fontSize    : nil,
                                 flags       : [ .selectable ],
                                 indentStyle : .system,
                                 autoPairs   : [:],
-                                inset       : .init(width: 8, height: 8))
+                                inset       : .init(width: 8, height: 8),
+                                autoscroll  : false)
       .frame(width: 200, height: 100)
     
     UXCodeTextViewRepresentable(
@@ -228,13 +274,15 @@ struct UXCodeTextViewRepresentable_Previews: PreviewProvider {
         \bye
         """#
       ),
+      selection   : nil,
       language    : .tex,
       theme       : .pojoaque,
       fontSize    : nil,
       flags       : [ .selectable ],
       indentStyle : .system,
       autoPairs   : [:],
-      inset       : .init(width: 8, height: 8)
+      inset       : .init(width: 8, height: 8),
+      autoscroll  : false
     )
     .frame(width: 540, height: 200)
   }

--- a/Sources/CodeEditor/UXCodeTextViewRepresentable.swift
+++ b/Sources/CodeEditor/UXCodeTextViewRepresentable.swift
@@ -96,7 +96,7 @@ struct UXCodeTextViewRepresentable : UXViewRepresentable {
       }    
     #elseif os(iOS)
       public func textViewDidChange(_ textView: UITextView) {
-        parnt.source.wrappedValue = textView.string
+        parent.source.wrappedValue = textView.string
       }
     #else
       #error("Unsupported OS")

--- a/Sources/CodeEditor/UXCodeTextViewRepresentable.swift
+++ b/Sources/CodeEditor/UXCodeTextViewRepresentable.swift
@@ -77,7 +77,14 @@ struct UXCodeTextViewRepresentable : UXViewRepresentable {
   private let inset       : CGSize
   private let autoPairs   : [ String : String ]
   private let autoscroll  : Bool
-  
+
+  // The inner `value` is true, exactly when execution is inside
+  // the `updateTextView(_:)` method. The `Coordinator` can use this
+  // value to guard against update cycles.
+  // This needs to be a `State`, as the `UXCodeTextViewRepresentable`
+  // might be destructed and recreated in between calls to `makeCoordinator()`
+  // and `updateTextView(_:)`.
+  @State private var isCurrentlyUpdatingView = ReferenceTypeBool(value: false)
   
   // MARK: - TextView Delegate  Coordinator
     
@@ -111,6 +118,14 @@ struct UXCodeTextViewRepresentable : UXViewRepresentable {
     #endif
       
     public func textViewDidChangeSelection(_ notification: Notification) {
+      // This function may be called as a consequence of calling
+      // `textView.setSelectedRange(_:)` in UXCodeTextViewRepresentable/updateTextView(_:)`.
+      // Since this function might update the `parent.selection` `Binding`, which in
+      // turn might update a `State`, this would lead to undefined behavior.
+      guard !parent.isCurrentlyUpdatingView.value else {
+        return
+      }
+      
       guard let textView = notification.object as? UXTextView else {
         assertionFailure("unexpected notification object")
         return
@@ -125,10 +140,8 @@ struct UXCodeTextViewRepresentable : UXViewRepresentable {
         return
       }
         
-      DispatchQueue.main.async {
-        if selection.wrappedValue != range {
-          selection.wrappedValue = range
-        }
+      if selection.wrappedValue != range {
+        selection.wrappedValue = range
       }
     }
     
@@ -143,6 +156,11 @@ struct UXCodeTextViewRepresentable : UXViewRepresentable {
   }
   
   private func updateTextView(_ textView: UXCodeTextView) {
+    isCurrentlyUpdatingView.value = true
+    defer {
+      isCurrentlyUpdatingView.value = false
+    }
+      
     if let binding = fontSize {
       textView.applyNewTheme(themeName, andFontSize: binding.wrappedValue)
     }
@@ -237,6 +255,18 @@ struct UXCodeTextViewRepresentable : UXViewRepresentable {
       updateTextView(textView)
     }
   #endif // iOS
+}
+
+extension UXCodeTextViewRepresentable {
+  // A wrapper around a `Bool` that enables updating
+  // the wrapped value during `View` renders.
+  private class ReferenceTypeBool {
+    var value: Bool
+      
+    init(value: Bool) {
+      self.value = value
+    }
+  }
 }
 
 struct UXCodeTextViewRepresentable_Previews: PreviewProvider {


### PR DESCRIPTION
This PR addresses #2.

 The selected text range can be observed and modified via another `Binding` now:
 
 ```swift
  struct ContentView: View {
     static private let initialSource = "let a = 42\n"

     @State private var source = Self.initialSource
     @State private var selection = Self.initialSource.endIndex..<Self.initialSource.endIndex

     var body: some View {
         CodeEditor(source: $source,
                    selection: $selection,
                    language: .swift,
                    theme: .ocean,
                    autoscroll: false)
         Button("Select All") {
             selection = source.startIndex..<source.endIndex
         }
     }
 }
 ```
 When `autoscroll` is `true`, the editor automatically scrolls to the respective
 cursor position when `selection` is modfied from the outside, i.e. programatically.