### PR TITLE
Add missing delegate function (iOS)

### DIFF
--- a/Sources/CodeEditor/UXCodeTextViewRepresentable.swift
+++ b/Sources/CodeEditor/UXCodeTextViewRepresentable.swift
@@ -94,6 +94,12 @@ struct UXCodeTextViewRepresentable : UXViewRepresentable {
       parent.source.wrappedValue = textView.string
     }
     
+    #if os(iOS)
+    public func textViewDidChange(_ textView: UITextView) {
+      parent.source.wrappedValue = textView.string
+    }
+    #endif
+    
     var allowCopy: Bool {
       return parent.flags.contains(.selectable)
           || parent.flags.contains(.editable)


### PR DESCRIPTION
## Summary

This PR adds missing `UITextViewDelegate`'s function, which fixes #6.

## What was done

- [x] Implement `textViewDidChange(_ textView: UITextView)` function in `UXCodeTextViewRepresentable.Coordinator` class.