### PR TITLE
disable autocorrection/spellcheck and smartQuotes

### DIFF
--- a/Sources/CodeEditor/UXCodeTextViewRepresentable.swift
+++ b/Sources/CodeEditor/UXCodeTextViewRepresentable.swift
@@ -272,6 +272,9 @@ struct UXCodeTextViewRepresentable : UXViewRepresentable {
       #if os(iOS)
       textView.autocapitalizationType = .none
       textView.smartDashesType = .no
+      textView.autocorrectionType = .no
+      textView.spellCheckingType = .no
+      textView.smartQuotesType = .no
       #endif
       updateTextView(textView)
       return textView


### PR DESCRIPTION
All those iOS smartness is not helping for a code editor. So disabled even more