### PR TITLE
Correction of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,8 +214,8 @@ struct ContentView: View {
               .tag(language)
           }
         }
-        Picker("Theme", selection: $theme) { theme in
-          ForEach(CodeEditor.availableThemes) {
+        Picker("Theme", selection: $theme) {
+          ForEach(CodeEditor.availableThemes) { theme in
             Text("\(theme.rawValue.capitalized)")
               .tag(theme)
           }


### PR DESCRIPTION
I noticed that the README was wrong, so I fixed it.

```
Picker("Theme", selection: $theme) { theme in
  ForEach(CodeEditor.availableThemes) {
    Text("\(theme.rawValue.capitalized)")
      .tag(theme)
  }
}
```

↓ Change ↓

```
Picker("Theme", selection: $theme) {
  ForEach(CodeEditor.availableThemes) { theme in
    Text("\(theme.rawValue.capitalized)")
      .tag(theme)
  }
}
```