### PR TITLE
Fix bold text flickering and theme switching on every view update

### DIFF
--- a/Sources/CodeEditor/UXCodeTextView.swift
+++ b/Sources/CodeEditor/UXCodeTextView.swift
@@ -256,13 +256,22 @@ final class UXCodeTextView: UXTextView {
   func applyNewTheme(_ newTheme: CodeEditor.ThemeName? = nil,
                      andFontSize newSize: CGFloat) -> Bool
   {
+    let resolvedTheme = newTheme ?? themeName
+
+    // Skip expensive setTheme reload when neither theme nor font size changed.
+    if resolvedTheme == themeName,
+       let existingFont = highlightr?.theme?.codeFont,
+       existingFont.pointSize == newSize {
+      return true
+    }
+
     // Setting the theme reloads it (i.e. makes a "copy").
     guard let highlightr = highlightr,
-          highlightr.setTheme(to: (newTheme ?? themeName).rawValue),
+          highlightr.setTheme(to: resolvedTheme.rawValue),
           let theme      = highlightr.theme else { return false }
-    
+
     guard theme.codeFont?.pointSize != newSize else { return true }
-    
+
     theme.codeFont       = theme.codeFont?      .withSize(newSize)
     theme.boldCodeFont   = theme.boldCodeFont?  .withSize(newSize)
     theme.italicCodeFont = theme.italicCodeFont?.withSize(newSize)

--- a/Sources/CodeEditor/UXCodeTextView.swift
+++ b/Sources/CodeEditor/UXCodeTextView.swift
@@ -58,6 +58,7 @@ final class UXCodeTextView: UXTextView {
   }
   private(set) var themeName = CodeEditor.ThemeName.default {
     didSet {
+      guard themeName != oldValue else { return }
       highlightr?.setTheme(to: themeName.rawValue)
       if let font = highlightr?.theme?.codeFont { self.font = font }
     }
@@ -247,6 +248,7 @@ final class UXCodeTextView: UXTextView {
     guard let highlightr = highlightr,
           highlightr.setTheme(to: newTheme.rawValue),
           let theme      = highlightr.theme else { return false }
+    themeName = newTheme
     self.backgroundColor = customBackgroundColor ?? theme.themeBackgroundColor
     if let font = theme.codeFont, font !== self.font { self.font = font }
     return true
@@ -257,9 +259,10 @@ final class UXCodeTextView: UXTextView {
                      andFontSize newSize: CGFloat) -> Bool
   {
     let resolvedTheme = newTheme ?? themeName
+    let themeChanged = resolvedTheme != themeName
 
     // Skip expensive setTheme reload when neither theme nor font size changed.
-    if resolvedTheme == themeName,
+    if !themeChanged,
        let existingFont = highlightr?.theme?.codeFont,
        existingFont.pointSize == newSize {
       return true
@@ -269,6 +272,8 @@ final class UXCodeTextView: UXTextView {
     guard let highlightr = highlightr,
           highlightr.setTheme(to: resolvedTheme.rawValue),
           let theme      = highlightr.theme else { return false }
+
+    if themeChanged { themeName = resolvedTheme }
 
     guard theme.codeFont?.pointSize != newSize else { return true }
 


### PR DESCRIPTION
## Summary

- **Fix bold text flickering on every click/interaction**: `applyNewTheme(_:andFontSize:)` was calling `highlightr.setTheme(to:)` on every SwiftUI view update even when the theme and font size hadn't changed. This caused the entire text storage to be re-highlighted, momentarily stripping and reapplying bold attributes and causing visible flicker. Added an early return when both the resolved theme name and font size are unchanged.

- **Fix theme not updating and track themeName correctly**: `applyNewTheme` methods were not updating the stored `themeName` property after successfully applying a new theme. This meant the early-return guard couldn't correctly detect when a theme had changed, causing some theme switches (via settings) to silently fail. Added `themeName = resolvedTheme` after successful apply, and a `guard themeName != oldValue` in the `didSet` to prevent redundant double-application.

## Test plan

- [ ] Open a CodeEditor with `fontSize` binding and a theme set
- [ ] Click repeatedly in the editor — bold text should remain stable (no flicker)
- [ ] Change the theme programmatically — should apply immediately
- [ ] Change it back — should apply without needing to close/reopen the editor